### PR TITLE
Add unit test for CommandMakeCommand

### DIFF
--- a/tests/Feature/CommandMakeCommandTest.php
+++ b/tests/Feature/CommandMakeCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Juzaweb\DevTool\Tests\Feature;
+
+use Illuminate\Support\Facades\File;
+use Juzaweb\DevTool\Tests\TestCase;
+use Juzaweb\Modules\Core\Modules\Support\Stub;
+use Juzaweb\Modules\Core\Providers\CoreServiceProvider;
+use Juzaweb\Modules\Core\Translations\TranslationsServiceProvider;
+
+class CommandMakeCommandTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return array_merge(
+            parent::getPackageProviders($app),
+            [
+                CoreServiceProvider::class,
+                TranslationsServiceProvider::class,
+            ]
+        );
+    }
+
+    protected function getPackageAliases($app)
+    {
+        return [
+            'Theme' => \Juzaweb\Modules\Core\Facades\Theme::class,
+            'Module' => \Juzaweb\Modules\Core\Facades\Module::class,
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup module configuration
+        $this->app['config']->set('modules.paths.modules', base_path('modules'));
+        $this->app['config']->set('modules.paths.generator.command.path', 'Console');
+        $this->app['config']->set('modules.paths.generator.command.generate', true);
+        $this->app['config']->set('dev-tool.modules.stubs.path', dirname(__DIR__, 2) . '/stubs/modules/');
+        $this->app['config']->set('modules.stubs.path', dirname(__DIR__, 2) . '/stubs/modules/');
+
+        Stub::setBasePath(dirname(__DIR__, 2) . '/stubs/modules/');
+
+        // Create a dummy module
+        if (!File::isDirectory(base_path('modules/Blog'))) {
+            File::makeDirectory(base_path('modules/Blog'), 0755, true);
+        }
+
+        // Create module.json
+        File::put(base_path('modules/Blog/module.json'), json_encode([
+            'name' => 'Blog',
+            'alias' => 'blog',
+            'description' => 'Blog module',
+            'keywords' => [],
+            'active' => 1,
+            'order' => 0,
+            'providers' => [],
+            'aliases' => [],
+            'files' => [],
+            'requires' => []
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(base_path('modules'));
+        parent::tearDown();
+    }
+
+    public function test_it_creates_command_file()
+    {
+        $this->artisan('module:make-command', ['name' => 'CreatePostCommand', 'module' => 'Blog'])
+            ->assertExitCode(0);
+
+        $this->assertFileExists(base_path('modules/Blog/Console/CreatePostCommand.php'));
+
+        $content = File::get(base_path('modules/Blog/Console/CreatePostCommand.php'));
+
+        $this->assertStringContainsString('class CreatePostCommand extends Command', $content);
+        $this->assertStringContainsString('protected $name = \'command:name\';', $content);
+    }
+
+    public function test_it_creates_command_file_with_custom_command_name()
+    {
+        $this->artisan('module:make-command', ['name' => 'AnotherCommand', 'module' => 'Blog', '--command' => 'blog:another'])
+            ->assertExitCode(0);
+
+        $this->assertFileExists(base_path('modules/Blog/Console/AnotherCommand.php'));
+
+        $content = File::get(base_path('modules/Blog/Console/AnotherCommand.php'));
+
+        $this->assertStringContainsString('protected $name = \'blog:another\';', $content);
+    }
+}


### PR DESCRIPTION
This PR adds a feature test for `CommandMakeCommand`. It ensures that the `module:make-command` artisan command correctly generates a console command file within a module structure. The test sets up a temporary module environment, runs the command, and verifies the existence and content of the generated file. It also covers the custom command name option.

---
*PR created automatically by Jules for task [6176541710342917267](https://jules.google.com/task/6176541710342917267) started by @juzaweb*