### PR TITLE
Add unit test for DatatableMakeCommand

### DIFF
--- a/tests/Unit/DatatableMakeCommandTest.php
+++ b/tests/Unit/DatatableMakeCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Juzaweb\DevTool\Tests\Unit;
+
+use Illuminate\Support\Facades\File;
+use Juzaweb\DevTool\Tests\TestCase;
+use Juzaweb\Modules\Core\Modules\Support\Stub;
+
+class DatatableMakeCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup module configuration
+        $this->app['config']->set('modules.paths.modules', base_path('modules'));
+        $this->app['config']->set('modules.paths.generator.datatable.path', 'src/Http/DataTables');
+        $this->app['config']->set('modules.paths.generator.datatable.generate', true);
+        $this->app['config']->set('modules.paths.generator.datatable.namespace', 'Http/DataTables');
+        $this->app['config']->set('dev-tool.modules.stubs.path', dirname(__DIR__, 2) . '/stubs/modules/');
+        $this->app['config']->set('modules.stubs.path', dirname(__DIR__, 2) . '/stubs/modules/');
+
+        Stub::setBasePath(dirname(__DIR__, 2) . '/stubs/modules/');
+
+        // Create a dummy module
+        if (!File::isDirectory(base_path('modules/Blog'))) {
+            File::makeDirectory(base_path('modules/Blog'), 0755, true);
+        }
+
+        // Create module.json
+        File::put(base_path('modules/Blog/module.json'), json_encode([
+            'name' => 'Blog',
+            'alias' => 'blog',
+            'description' => 'Blog module',
+            'keywords' => [],
+            'active' => 1,
+            'order' => 0,
+            'providers' => [],
+            'aliases' => [],
+            'files' => [],
+            'requires' => []
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(base_path('modules'));
+        parent::tearDown();
+    }
+
+    public function test_it_creates_datatable_file()
+    {
+        $this->artisan('module:make-datatable', ['datatable' => 'Post', 'module' => 'Blog'])
+            ->assertExitCode(0);
+
+        $this->assertFileExists(base_path('modules/Blog/src/Http/DataTables/PostsDataTable.php'));
+
+        $content = File::get(base_path('modules/Blog/src/Http/DataTables/PostsDataTable.php'));
+
+        $this->assertStringContainsString('class PostsDataTable extends DataTable', $content);
+        $this->assertStringContainsString('namespace Juzaweb\Modules\Blog\Http\DataTables;', $content);
+    }
+}


### PR DESCRIPTION
Added unit test for `DatatableMakeCommand` to ensure correct file generation and namespace handling.
- Created `tests/Unit/DatatableMakeCommandTest.php`.
- Verified command execution and file content.
- Configured test environment with necessary module paths and stubs.

---
*PR created automatically by Jules for task [1786719170780585747](https://jules.google.com/task/1786719170780585747) started by @juzaweb*