### PR TITLE
Add unit test for MailMakeCommand

### DIFF
--- a/tests/Unit/MailMakeCommandTest.php
+++ b/tests/Unit/MailMakeCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Juzaweb\DevTool\Tests\Unit;
+
+use Illuminate\Support\Facades\File;
+use Juzaweb\DevTool\Tests\TestCase;
+use Juzaweb\Modules\Core\Modules\Support\Stub;
+
+class MailMakeCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup module configuration
+        $this->app['config']->set('modules.paths.modules', base_path('modules'));
+        $this->app['config']->set('modules.paths.generator.emails.path', 'src/Emails');
+        $this->app['config']->set('modules.paths.generator.emails.generate', true);
+        $this->app['config']->set('dev-tool.modules.stubs.path', dirname(__DIR__, 2) . '/stubs/modules/');
+        $this->app['config']->set('modules.stubs.path', dirname(__DIR__, 2) . '/stubs/modules/');
+
+        Stub::setBasePath(dirname(__DIR__, 2) . '/stubs/modules/');
+
+        // Create a dummy module
+        if (!File::isDirectory(base_path('modules/Blog'))) {
+            File::makeDirectory(base_path('modules/Blog'), 0755, true);
+        }
+
+        // Create module.json
+        File::put(base_path('modules/Blog/module.json'), json_encode([
+            'name' => 'Blog',
+            'alias' => 'blog',
+            'description' => 'Blog module',
+            'keywords' => [],
+            'active' => 1,
+            'order' => 0,
+            'providers' => [],
+            'aliases' => [],
+            'files' => [],
+            'requires' => []
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(base_path('modules'));
+        parent::tearDown();
+    }
+
+    public function test_it_creates_mail_file()
+    {
+        $this->artisan('module:make-mail', ['name' => 'MyMail', 'module' => 'Blog'])
+            ->assertExitCode(0);
+
+        $this->assertFileExists(base_path('modules/Blog/src/Emails/MyMail.php'));
+
+        $content = File::get(base_path('modules/Blog/src/Emails/MyMail.php'));
+
+        $this->assertStringContainsString('class MyMail extends Mailable', $content);
+        $this->assertStringContainsString('namespace Juzaweb\Modules\Blog\Emails;', $content);
+    }
+}


### PR DESCRIPTION
Added a unit test for the `MailMakeCommand` to ensure it correctly generates Mailable classes within a module. The test verifies that the command creates the file in the expected location (`modules/Blog/src/Emails/MyMail.php`) and contains the correct namespace and class definition.

---
*PR created automatically by Jules for task [5027622459082868463](https://jules.google.com/task/5027622459082868463) started by @juzaweb*