### PR TITLE
Add unit test for ModuleDeleteCommand

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,7 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders($app)
     {
         return [
+            \Juzaweb\QueryCache\QueryCacheServiceProvider::class,
             CoreServiceProvider::class,
             DevToolServiceProvider::class,
         ];

--- a/tests/Unit/ModuleDeleteCommandTest.php
+++ b/tests/Unit/ModuleDeleteCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Juzaweb\DevTool\Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Juzaweb\DevTool\Tests\TestCase;
+use Juzaweb\Modules\Core\Modules\Support\Stub;
+
+class ModuleDeleteCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Setup module configuration
+        $this->app['config']->set('modules.paths.modules', base_path('modules'));
+        $this->app['config']->set('dev-tool.modules.stubs.path', dirname(__DIR__, 2) . '/stubs/modules/');
+        $this->app['config']->set('modules.stubs.path', dirname(__DIR__, 2) . '/stubs/modules/');
+
+        Stub::setBasePath(dirname(__DIR__, 2) . '/stubs/modules/');
+
+        // Create a dummy module
+        if (!File::isDirectory(base_path('modules/Blog'))) {
+            File::makeDirectory(base_path('modules/Blog'), 0755, true);
+        }
+
+        // Create module.json
+        File::put(base_path('modules/Blog/module.json'), json_encode([
+            'name' => 'Blog',
+            'alias' => 'blog',
+            'description' => 'Blog module',
+            'keywords' => [],
+            'active' => 1,
+            'order' => 0,
+            'providers' => [],
+            'aliases' => [],
+            'files' => [],
+            'requires' => []
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(base_path('modules'));
+        parent::tearDown();
+    }
+
+    public function test_it_deletes_module()
+    {
+        $this->assertDirectoryExists(base_path('modules/Blog'));
+
+        $this->artisan('module:delete', ['module' => 'Blog'])
+            ->assertExitCode(0);
+
+        $this->assertDirectoryDoesNotExist(base_path('modules/Blog'));
+    }
+}


### PR DESCRIPTION
This PR adds a unit test for the `ModuleDeleteCommand`. It verifies that the command correctly deletes a module directory. The `tests/TestCase.php` was also updated to include the `QueryCacheServiceProvider` which is a dependency for the core module system used in the test.

---
*PR created automatically by Jules for task [1674413772616493237](https://jules.google.com/task/1674413772616493237) started by @juzaweb*