### PR TITLE
🧪 Add unit tests for GithubReleaseModuleCommand

### DIFF
--- a/tests/Unit/GithubReleaseModuleCommandTest.php
+++ b/tests/Unit/GithubReleaseModuleCommandTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Juzaweb\DevTool\Tests\Unit;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Juzaweb\DevTool\Commands\GithubReleaseModuleCommand;
+use Juzaweb\DevTool\Tests\TestCase;
+use Mockery;
+
+class GithubReleaseModuleCommandTest extends TestCase
+{
+    public function testNothingToRelease()
+    {
+        $command = Mockery::mock(GithubReleaseModuleCommand::class . '[runCmd,getGithubToken]')
+            ->shouldAllowMockingProtectedMethods();
+
+        $command->shouldReceive('getGithubToken')->andReturn('fake-token');
+
+        // Mock getRepo and getLastTag outputs
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return is_string($cmd) && str_contains($cmd, 'git ls-remote --tags');
+            })
+            ->andReturn('refs/tags/v1.0.0');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return is_string($cmd) && str_contains($cmd, 'git config --get remote.origin.url');
+            })
+            ->andReturn('fake/repo');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return $cmd === 'git pull';
+            })
+            ->andReturn('');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return is_string($cmd) && str_contains($cmd, 'git log');
+            })
+            ->andReturn('');
+
+        $this->app[\Illuminate\Contracts\Console\Kernel::class]->registerCommand($command);
+
+        File::shouldReceive('isDirectory')->andReturn(true);
+
+        $this->artisan('github:release', [
+            'path' => '/fake/path'
+        ])
+            ->expectsOutput('Nothing to release')
+            ->assertExitCode(0);
+    }
+
+    public function testReleaseWithChangelog()
+    {
+        $command = Mockery::mock(GithubReleaseModuleCommand::class . '[runCmd,getGithubToken]')
+            ->shouldAllowMockingProtectedMethods();
+
+        $command->shouldReceive('getGithubToken')->andReturn('fake-token');
+
+        // Mock getRepo and getLastTag outputs
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return is_string($cmd) && str_contains($cmd, 'git ls-remote --tags');
+            })
+            ->andReturn('refs/tags/v1.0.0');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return is_string($cmd) && str_contains($cmd, 'git config --get remote.origin.url');
+            })
+            ->andReturn('fake/repo');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return $cmd === 'git pull';
+            })
+            ->andReturn('');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return is_string($cmd) && str_contains($cmd, 'git log');
+            })
+            ->andReturn("* Feature 1\n* Feature 2\n* :construction: WIP"); // :construction: should be filtered out
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return $cmd === 'git add changelog.md';
+            })
+            ->andReturn('');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return is_string($cmd) && str_contains($cmd, 'git commit -o changelog.md');
+            })
+            ->andReturn('');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return $cmd === 'git push';
+            })
+            ->andReturn('');
+
+        $this->app[\Illuminate\Contracts\Console\Kernel::class]->registerCommand($command);
+
+        File::shouldReceive('isDirectory')->andReturn(true);
+        File::shouldReceive('prepend')
+            ->withArgs(function ($path, $content) {
+                return str_contains($path, 'changelog.md') && str_contains($content, 'v1.0.1') && str_contains($content, 'Feature 1') && !str_contains($content, ':construction:');
+            })
+            ->once();
+
+        Http::fake([
+            'https://api.github.com/repos/fake/repo/releases' => Http::response(['html_url' => 'https://github.com/fake/repo/releases/tag/1.0.1'], 201),
+        ]);
+
+        $this->artisan('github:release', [
+            'path' => '/fake/path'
+        ])
+            ->expectsOutput('Add changelog')
+            ->expectsOutput('Release v1.0.1')
+            ->expectsOutput('Released url: https://github.com/fake/repo/releases/tag/1.0.1')
+            ->assertExitCode(0);
+
+        Http::assertSent(function ($request) {
+            return $request->url() == 'https://api.github.com/repos/fake/repo/releases' &&
+                   $request['tag_name'] == '1.0.1' &&
+                   $request['body'] == "* Feature 1\n* Feature 2" &&
+                   $request->header('Authorization')[0] == 'Bearer fake-token';
+        });
+    }
+
+    public function testReleaseWithoutChangelog()
+    {
+        $command = Mockery::mock(GithubReleaseModuleCommand::class . '[runCmd,getGithubToken]')
+            ->shouldAllowMockingProtectedMethods();
+
+        $command->shouldReceive('getGithubToken')->andReturn('fake-token');
+
+        // Mock getRepo and getLastTag outputs
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return is_string($cmd) && str_contains($cmd, 'git ls-remote --tags');
+            })
+            ->andReturn('refs/tags/v1.0.0');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return is_string($cmd) && str_contains($cmd, 'git config --get remote.origin.url');
+            })
+            ->andReturn('fake/repo');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return $cmd === 'git pull';
+            })
+            ->andReturn('');
+
+        $command->shouldReceive('runCmd')
+            ->withArgs(function ($path, $cmd) {
+                return is_string($cmd) && str_contains($cmd, 'git log');
+            })
+            ->andReturn("* Fix bug 1");
+
+        $this->app[\Illuminate\Contracts\Console\Kernel::class]->registerCommand($command);
+
+        File::shouldReceive('isDirectory')->andReturn(true);
+        // Prepend shouldn't be called
+
+        Http::fake([
+            'https://api.github.com/repos/fake/repo/releases' => Http::response(['html_url' => 'https://github.com/fake/repo/releases/tag/1.0.1'], 201),
+        ]);
+
+        $this->artisan('github:release', [
+            'path' => '/fake/path',
+            '--changelog' => false,
+        ])
+            ->expectsOutput('Release v1.0.1')
+            ->expectsOutput('Released url: https://github.com/fake/repo/releases/tag/1.0.1')
+            ->doesntExpectOutput('Add changelog')
+            ->assertExitCode(0);
+
+        Http::assertSent(function ($request) {
+            return $request->url() == 'https://api.github.com/repos/fake/repo/releases' &&
+                   $request['tag_name'] == '1.0.1' &&
+                   $request['body'] == "* Fix bug 1" &&
+                   $request->header('Authorization')[0] == 'Bearer fake-token';
+        });
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the `GithubReleaseModuleCommand`'s main `handle()` method, which runs local `git` processes and external HTTP requests.
  
📊 **Coverage:** Three main scenarios are now covered:
1.  **Nothing to release:** Checks how the command behaves when `git log` returns no output.
2.  **Release with changelog:** The default happy-path scenario where a changelog is parsed, a file is written/prepended, `git add/commit/push` is simulated, and a release is posted to the GitHub API.
3.  **Release without changelog:** The `--changelog=false` flag scenario, which skips file writing and commits, but still successfully posts to the GitHub API.

✨ **Result:** A significant improvement in test coverage and reliability. The `handle` method is fully verified without requiring real, destructive Git operations or actual external API requests, preventing unexpected failures during automated testing.

---
*PR created automatically by Jules for task [18309950654553099013](https://jules.google.com/task/18309950654553099013) started by @juzaweb*