### PR TITLE
🧪 Add tests for FileGenerator generate method

### DIFF
--- a/src/Generators/FileGenerator.php
+++ b/src/Generators/FileGenerator.php
@@ -30,7 +30,7 @@ class FileGenerator extends Generator
     /**
      * @var bool
      */
-    private bool $overwriteFile;
+    private bool $overwriteFile = false;
 
     /**
      * The constructor.

--- a/tests/Unit/FileGeneratorTest.php
+++ b/tests/Unit/FileGeneratorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Juzaweb\DevTool\Tests\Unit;
+
+use Illuminate\Filesystem\Filesystem;
+use Juzaweb\DevTool\Generators\FileGenerator;
+use Juzaweb\DevTool\Tests\TestCase;
+use Juzaweb\Modules\Core\Modules\Exceptions\FileAlreadyExistException;
+use Mockery;
+
+class FileGeneratorTest extends TestCase
+{
+    public function test_it_generates_file_when_not_exists()
+    {
+        $path = '/fake/path/file.txt';
+        $contents = 'fake contents';
+
+        $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->once()->with($path)->andReturn(false);
+        $filesystem->shouldReceive('put')->once()->with($path, $contents)->andReturn(13);
+
+        $generator = new FileGenerator($path, $contents, $filesystem);
+
+        $this->assertEquals(13, $generator->generate());
+    }
+
+    public function test_it_generates_file_when_exists_and_overwrite_is_true()
+    {
+        $path = '/fake/path/file.txt';
+        $contents = 'fake contents';
+
+        $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->once()->with($path)->andReturn(true);
+        $filesystem->shouldReceive('put')->once()->with($path, $contents)->andReturn(13);
+
+        $generator = new FileGenerator($path, $contents, $filesystem);
+        $generator->withFileOverwrite(true);
+
+        $this->assertEquals(13, $generator->generate());
+    }
+
+    public function test_it_throws_exception_when_file_exists_and_overwrite_is_false()
+    {
+        $path = '/fake/path/file.txt';
+        $contents = 'fake contents';
+
+        $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->once()->with($path)->andReturn(true);
+        $filesystem->shouldReceive('put')->never();
+
+        $generator = new FileGenerator($path, $contents, $filesystem);
+        $generator->withFileOverwrite(false);
+
+        $this->expectException(FileAlreadyExistException::class);
+        $this->expectExceptionMessage('File already exists!');
+
+        $generator->generate();
+    }
+
+    public function test_it_throws_exception_when_file_exists_and_overwrite_is_not_set()
+    {
+        $path = '/fake/path/file.txt';
+        $contents = 'fake contents';
+
+        $filesystem = Mockery::mock(Filesystem::class);
+        $filesystem->shouldReceive('exists')->once()->with($path)->andReturn(true);
+        $filesystem->shouldReceive('put')->never();
+
+        $generator = new FileGenerator($path, $contents, $filesystem);
+
+        $this->expectException(FileAlreadyExistException::class);
+        $this->expectExceptionMessage('File already exists!');
+
+        $generator->generate();
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `generate` method of `FileGenerator` lacked unit tests. Furthermore, when writing tests for it, I discovered that the `overwriteFile` property could throw an uninitialized typed property exception in modern PHP versions.

📊 **Coverage:** Covered all logical branches of the `generate` method:
- Happy path: Writing a new file that doesn't exist.
- Happy path: Overwriting an existing file when `$overwriteFile` is true.
- Error path: Throwing `FileAlreadyExistException` when trying to write to an existing file when `$overwriteFile` is false.
- Error path: Throwing `FileAlreadyExistException` when trying to write to an existing file when `$overwriteFile` is not set (and defaulting to false).

✨ **Result:** Test coverage for this fundamental generator class is greatly improved and a potential bug was fixed. All tests pass with no regressions.

---
*PR created automatically by Jules for task [14428379588896732541](https://jules.google.com/task/14428379588896732541) started by @juzaweb*