### PR TITLE
ci: add pint code style check to tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,6 @@ jobs:
 
       - name: Execute pint
         run: vendor/bin/pint --test
-        continue-on-error: true
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Execute pint
         run: vendor/bin/pint --test
+        continue-on-error: true
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,5 +40,8 @@ jobs:
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
+      - name: Execute pint
+        run: vendor/bin/pint --test
+
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "require-dev": {
         "roave/security-advisories": "dev-latest",
         "laravel/framework": "^11.34",
+        "laravel/pint": "^1.13",
         "orchestra/testbench": "^9.0",
         "phpunit/phpunit": "^11.0",
         "mockery/mockery": "^1.6",


### PR DESCRIPTION
Added a step in `.github/workflows/tests.yml` to execute Laravel Pint in test mode (`vendor/bin/pint --test`) directly after dependency installation and before the PHPUnit tests. This ensures that CI jobs fail fast if code style issues exist.

---
*PR created automatically by Jules for task [3123542341504426645](https://jules.google.com/task/3123542341504426645) started by @juzaweb*